### PR TITLE
Fixing regex for retry.yml and vdi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant/
-*.vdi/
-*.retry.yml/
+*.vdi
+*.retry.yml


### PR DESCRIPTION
Removing forward slash (`/`) from the end of `*.vdi` and `*.retry.yml` file match in `.gitignore`.